### PR TITLE
Propagate quote errors instead of panicking

### DIFF
--- a/rust-sdk/src/quote.rs
+++ b/rust-sdk/src/quote.rs
@@ -1,4 +1,4 @@
-use anyhow::{ensure, Context, Ok, Result};
+use anyhow::{ensure, Context, Result};
 use cp_amm::{
     params::swap::TradeDirection,
     state::{fee::FeeMode, Pool, SwapResult},
@@ -15,7 +15,7 @@ pub fn get_quote(
 ) -> Result<SwapResult> {
     ensure!(actual_amount_in > 0, "amount is zero");
 
-    let result = get_internal_quote(
+    get_internal_quote(
         pool,
         current_timestamp,
         current_slot,
@@ -23,8 +23,6 @@ pub fn get_quote(
         a_to_b,
         has_referral,
     )
-    .unwrap();
-    Ok(result)
 }
 
 fn get_internal_quote(


### PR DESCRIPTION
## Summary
- propagate errors from the quote helper instead of unwrapping results
- allow callers to receive proper swap errors when a pool is disabled or not yet active

## Testing
- cargo test -p rust-sdk

------
https://chatgpt.com/codex/tasks/task_e_68e504e77b70832ea733d5fd2938b23c